### PR TITLE
Add random 15/30-node scenarios and Monte Carlo helpers

### DIFF
--- a/README-EXAMPLES.md
+++ b/README-EXAMPLES.md
@@ -162,6 +162,28 @@ platform/minimal-net/contiki-main.c to match your needs.
 Please consult cpu/native/net/README-WPCAP.md as well if you are running
 Microsoft Windows.
 
+waco-srdcp/
+-----------
+
+COOJA scenarios that integrate WaCo + SRDCP for data collection experiments on Sky motes. Build the firmware once:
+
+    cd examples/waco-srdcp
+    make example-runicast-srdcp.sky TARGET=sky
+
+Then launch one of the provided simulations under `examples/waco-srdcp/sim/`:
+
+* `waco-srdcp-grid-5-nodes/`, `waco-srdcp-grid-15-nodes/`, `waco-srdcp-grid-30-nodes/` – deterministic grid layouts.
+* `waco-srdcp-random-5-nodes/`, `waco-srdcp-random-15-nodes/`, `waco-srdcp-random-30-nodes/` – sample random layouts that keep all nodes within the 50 m radio range.
+
+For batch or headless runs, the Monte-Carlo helper scripts in the same folder wrap COOJA (`ant -nogui`) and parse the resulting logs. For example, to evaluate the random layouts with 20 seeds:
+
+    cd examples/waco-srdcp/sim
+    ./mc_random_5nodes.sh 20
+    ./mc_random_15nodes.sh 20
+    ./mc_random_30nodes.sh 20
+
+Each script stores results under `examples/waco-srdcp/sim/out/waco-srdcp-random-*-nodes-mc` by default. They collect CSV summaries (PDR, neighbours, energy) for each seed and aggregate them across all runs.
+
 webbrowser/
 -----------
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ Thumbs.db
 ---
 
 ## 12) Bản quyền & nguồn
-- WaCo: https://github.com/waco-sim/waco  
-- SRDCP: https://github.com/StefanoFioravanzo/SRDCP  
+- WaCo: https://github.com/waco-sim/waco
+- SRDCP: https://github.com/StefanoFioravanzo/SRDCP
 Repo này tuân theo giấy phép của các dự án gốc (xem LICENSE tương ứng nếu kèm theo).
+
+---
+
+## 13) COOJA scenarios & Monte Carlo scripts
+- **Scenarios:** `examples/waco-srdcp/sim/` chứa cả bố cục **grid** và bố cục **random** (5/15/30 nodes) đã cấu hình sẵn cho 50 m radio range. Các file `waco-srdcp-random-*-nodes/waco-srdcp-random-*-nodes.csc` cung cấp toạ độ mẫu (có thể mở trong COOJA để chỉnh tay nếu muốn).
+- **Batch runs:** dùng các script headless `examples/waco-srdcp/sim/mc_random_5nodes.sh`, `mc_random_15nodes.sh`, `mc_random_30nodes.sh` (`[NUM_SEEDS] [OUTDIR]`). Ví dụ `./mc_random_15nodes.sh 20` sẽ chạy 20 seeds, lưu log vào `examples/waco-srdcp/sim/out/waco-srdcp-random-15-nodes-mc/`, parse CSV (PDR UL/DL, neighbour stats) và cộng gộp năng lượng.
+- **Tuỳ biến:** có thể nhân bản script để hỗ trợ số node khác hoặc chèn bước sinh toạ độ ngẫu nhiên mỗi seed (ví dụ qua Python) trước khi gọi `ant -nogui`, miễn đảm bảo các mote vẫn nằm trong bán kính truyền 50 m.

--- a/examples/waco-srdcp/sim/mc_random_15nodes.sh
+++ b/examples/waco-srdcp/sim/mc_random_15nodes.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Monte Carlo headless runs for the 15-node random topology scenario
+# Usage: mc_random_15nodes.sh [NUM_SEEDS] [OUTDIR]
+# - NUM_SEEDS: số lần chạy (mặc định 10)
+# - OUTDIR: thư mục lưu kết quả (mặc định examples/waco-srdcp/sim/out/waco-srdcp-random-15-nodes-mc)
+
+NUM_SEEDS=${1:-10}
+
+# Chuẩn hoá đường dẫn tuyệt đối để chạy từ bất kỳ thư mục nào
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+OUTDIR=${2:-"$ROOT_DIR/examples/waco-srdcp/sim/out/waco-srdcp-random-15-nodes-mc"}
+
+COOJA_BUILD_XML="$ROOT_DIR/tools/cooja/build.xml"
+SCEN="$ROOT_DIR/examples/waco-srdcp/sim/waco-srdcp-random-15-nodes/waco-srdcp-random-15-nodes.csc"
+LOGDIR="$ROOT_DIR/examples/waco-srdcp/sim/waco-srdcp-random-15-nodes"
+
+echo "[mcR15] Chuẩn bị thư mục output: $OUTDIR"
+mkdir -p "$OUTDIR"
+
+if ! command -v ant >/dev/null 2>&1; then
+  echo "[mcR15][ERR] Không tìm thấy 'ant' trong PATH" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[mcR15][ERR] Không tìm thấy 'python3' trong PATH" >&2
+  exit 1
+fi
+
+echo "[mcR15] Build cooja jar (nếu cần)"
+ant -q -f "$COOJA_BUILD_XML" jar >/dev/null
+
+for s in $(seq 1 "$NUM_SEEDS"); do
+  echo "[mcR15] Seed $s / $NUM_SEEDS: chạy headless..."
+  ant -q -f "$COOJA_BUILD_XML" run_bigmem -Dargs="-nogui=$SCEN -random-seed=$s" >/dev/null
+
+  # Tìm file log mới nhất, ưu tiên file có timestamp, fallback nếu không có
+  latest_txt=$(ls -t "$LOGDIR"/waco-srdcp-random-15-nodes-*.txt 2>/dev/null | grep -v '_dc\.txt' | head -1 || true)
+  latest_dc=$(ls -t "$LOGDIR"/waco-srdcp-random-15-nodes-*_dc.txt 2>/dev/null | head -1 || true)
+  if [[ -z "${latest_txt}" ]]; then
+    # fallback không có suffix
+    latest_txt="$LOGDIR/waco-srdcp-random-15-nodes.txt"
+    latest_dc="$LOGDIR/waco-srdcp-random-15-nodes_dc.txt"
+  fi
+
+  if [[ ! -f "$latest_txt" ]]; then
+    echo "[mcR15][ERR] Không tìm thấy log TXT sau khi chạy seed=$s" >&2
+    exit 1
+  fi
+
+  dest_txt="$OUTDIR/seed-$s.txt"
+  echo "[mcR15] Seed $s: lưu log -> $dest_txt"
+  echo "[mcR15]   nguồn TXT: $latest_txt"
+  mv "$latest_txt" "$dest_txt"
+  if [[ -n "${latest_dc}" && -f "$latest_dc" ]]; then
+    echo "[mcR15]   nguồn DC:  $latest_dc"
+    mv "$latest_dc" "$OUTDIR/seed-${s}_dc.txt"
+  fi
+
+  echo "[mcR15] Seed $s: parse chỉ số -> CSV"
+  python3 "$ROOT_DIR/examples/waco-srdcp/sim/log_parser.py" "$dest_txt" --out-prefix "$OUTDIR/seed-$s" >/dev/null
+  if [[ -f "$OUTDIR/seed-${s}_dc.txt" ]]; then
+    echo "[mcR15] Seed $s: tính năng lượng (radio) -> CSV"
+    python3 "$ROOT_DIR/examples/waco-srdcp/sim/energy_parser.py" "$OUTDIR/seed-${s}_dc.txt" --out-prefix "$OUTDIR/seed-$s" >/dev/null
+  fi
+done
+
+# Tổng hợp trung bình mạng qua các seed
+agg="$OUTDIR/network_avgs.csv"
+echo "seed,prr_parent(last)_avg,prr_sender(last)_avg,prr_all_nei_avg_avg,PDR_UL(%)_avg,PDR_DL(%)_avg" > "$agg"
+for s in $(seq 1 "$NUM_SEEDS"); do
+  f="$OUTDIR/seed-${s}_network_avg.csv"
+  if [[ -f "$f" ]]; then
+    tail -n +2 "$f" | sed "s/^/$s,/" >> "$agg"
+  fi
+done
+
+# Tổng hợp năng lượng mạng qua các seed (nếu có)
+eagg="$OUTDIR/energy_network_avgs.csv"
+echo "seed,nodes,E_total_sum(J),E_total_avg_per_node(J),P_avg_per_node(mW)" > "$eagg"
+for s in $(seq 1 "$NUM_SEEDS"); do
+  f="$OUTDIR/seed-${s}_energy_network.csv"
+  if [[ -f "$f" ]]; then
+    tail -n +2 "$f" | sed "s/^/$s,/" >> "$eagg"
+  fi
+done
+
+# Trung bình theo node qua các seed (per-node metrics)
+summary_files=("$OUTDIR"/seed-*_summary.csv)
+if [[ -e "${summary_files[0]:-}" ]]; then
+  python3 "$ROOT_DIR/examples/waco-srdcp/sim/agg_per_node.py" --out "$OUTDIR/per_node_avg.csv" "${summary_files[@]}" >/dev/null || true
+fi
+
+# Trung bình theo mote qua các seed (năng lượng radio)
+energy_files=("$OUTDIR"/seed-*_energy_nodes.csv)
+if [[ -e "${energy_files[0]:-}" ]]; then
+  python3 "$ROOT_DIR/examples/waco-srdcp/sim/agg_per_node.py" --out "$OUTDIR/per_node_energy_avg.csv" "${energy_files[@]}" >/dev/null || true
+fi
+
+echo "[mcR15] Hoàn tất. Kết quả nằm ở: $OUTDIR"
+echo "[mcR15] Gợi ý: xem $agg, $eagg hoặc các file *_summary.csv/_network_avg.csv theo seed."

--- a/examples/waco-srdcp/sim/mc_random_30nodes.sh
+++ b/examples/waco-srdcp/sim/mc_random_30nodes.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Monte Carlo headless runs for the 30-node random topology scenario
+# Usage: mc_random_30nodes.sh [NUM_SEEDS] [OUTDIR]
+# - NUM_SEEDS: số lần chạy (mặc định 10)
+# - OUTDIR: thư mục lưu kết quả (mặc định examples/waco-srdcp/sim/out/waco-srdcp-random-30-nodes-mc)
+
+NUM_SEEDS=${1:-10}
+
+# Chuẩn hoá đường dẫn tuyệt đối để chạy từ bất kỳ thư mục nào
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+OUTDIR=${2:-"$ROOT_DIR/examples/waco-srdcp/sim/out/waco-srdcp-random-30-nodes-mc"}
+
+COOJA_BUILD_XML="$ROOT_DIR/tools/cooja/build.xml"
+SCEN="$ROOT_DIR/examples/waco-srdcp/sim/waco-srdcp-random-30-nodes/waco-srdcp-random-30-nodes.csc"
+LOGDIR="$ROOT_DIR/examples/waco-srdcp/sim/waco-srdcp-random-30-nodes"
+
+echo "[mcR30] Chuẩn bị thư mục output: $OUTDIR"
+mkdir -p "$OUTDIR"
+
+if ! command -v ant >/dev/null 2>&1; then
+  echo "[mcR30][ERR] Không tìm thấy 'ant' trong PATH" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[mcR30][ERR] Không tìm thấy 'python3' trong PATH" >&2
+  exit 1
+fi
+
+echo "[mcR30] Build cooja jar (nếu cần)"
+ant -q -f "$COOJA_BUILD_XML" jar >/dev/null
+
+for s in $(seq 1 "$NUM_SEEDS"); do
+  echo "[mcR30] Seed $s / $NUM_SEEDS: chạy headless..."
+  ant -q -f "$COOJA_BUILD_XML" run_bigmem -Dargs="-nogui=$SCEN -random-seed=$s" >/dev/null
+
+  # Tìm file log mới nhất, ưu tiên file có timestamp, fallback nếu không có
+  latest_txt=$(ls -t "$LOGDIR"/waco-srdcp-random-30-nodes-*.txt 2>/dev/null | grep -v '_dc\.txt' | head -1 || true)
+  latest_dc=$(ls -t "$LOGDIR"/waco-srdcp-random-30-nodes-*_dc.txt 2>/dev/null | head -1 || true)
+  if [[ -z "${latest_txt}" ]]; then
+    # fallback không có suffix
+    latest_txt="$LOGDIR/waco-srdcp-random-30-nodes.txt"
+    latest_dc="$LOGDIR/waco-srdcp-random-30-nodes_dc.txt"
+  fi
+
+  if [[ ! -f "$latest_txt" ]]; then
+    echo "[mcR30][ERR] Không tìm thấy log TXT sau khi chạy seed=$s" >&2
+    exit 1
+  fi
+
+  dest_txt="$OUTDIR/seed-$s.txt"
+  echo "[mcR30] Seed $s: lưu log -> $dest_txt"
+  echo "[mcR30]   nguồn TXT: $latest_txt"
+  mv "$latest_txt" "$dest_txt"
+  if [[ -n "${latest_dc}" && -f "$latest_dc" ]]; then
+    echo "[mcR30]   nguồn DC:  $latest_dc"
+    mv "$latest_dc" "$OUTDIR/seed-${s}_dc.txt"
+  fi
+
+  echo "[mcR30] Seed $s: parse chỉ số -> CSV"
+  python3 "$ROOT_DIR/examples/waco-srdcp/sim/log_parser.py" "$dest_txt" --out-prefix "$OUTDIR/seed-$s" >/dev/null
+  if [[ -f "$OUTDIR/seed-${s}_dc.txt" ]]; then
+    echo "[mcR30] Seed $s: tính năng lượng (radio) -> CSV"
+    python3 "$ROOT_DIR/examples/waco-srdcp/sim/energy_parser.py" "$OUTDIR/seed-${s}_dc.txt" --out-prefix "$OUTDIR/seed-$s" >/dev/null
+  fi
+done
+
+# Tổng hợp trung bình mạng qua các seed
+agg="$OUTDIR/network_avgs.csv"
+echo "seed,prr_parent(last)_avg,prr_sender(last)_avg,prr_all_nei_avg_avg,PDR_UL(%)_avg,PDR_DL(%)_avg" > "$agg"
+for s in $(seq 1 "$NUM_SEEDS"); do
+  f="$OUTDIR/seed-${s}_network_avg.csv"
+  if [[ -f "$f" ]]; then
+    tail -n +2 "$f" | sed "s/^/$s,/" >> "$agg"
+  fi
+done
+
+# Tổng hợp năng lượng mạng qua các seed (nếu có)
+eagg="$OUTDIR/energy_network_avgs.csv"
+echo "seed,nodes,E_total_sum(J),E_total_avg_per_node(J),P_avg_per_node(mW)" > "$eagg"
+for s in $(seq 1 "$NUM_SEEDS"); do
+  f="$OUTDIR/seed-${s}_energy_network.csv"
+  if [[ -f "$f" ]]; then
+    tail -n +2 "$f" | sed "s/^/$s,/" >> "$eagg"
+  fi
+done
+
+# Trung bình theo node qua các seed (per-node metrics)
+summary_files=("$OUTDIR"/seed-*_summary.csv)
+if [[ -e "${summary_files[0]:-}" ]]; then
+  python3 "$ROOT_DIR/examples/waco-srdcp/sim/agg_per_node.py" --out "$OUTDIR/per_node_avg.csv" "${summary_files[@]}" >/dev/null || true
+fi
+
+# Trung bình theo mote qua các seed (năng lượng radio)
+energy_files=("$OUTDIR"/seed-*_energy_nodes.csv)
+if [[ -e "${energy_files[0]:-}" ]]; then
+  python3 "$ROOT_DIR/examples/waco-srdcp/sim/agg_per_node.py" --out "$OUTDIR/per_node_energy_avg.csv" "${energy_files[@]}" >/dev/null || true
+fi
+
+echo "[mcR30] Hoàn tất. Kết quả nằm ở: $OUTDIR"
+echo "[mcR30] Gợi ý: xem $agg, $eagg hoặc các file *_summary.csv/_network_avg.csv theo seed."

--- a/examples/waco-srdcp/sim/mc_random_5nodes.sh
+++ b/examples/waco-srdcp/sim/mc_random_5nodes.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Monte Carlo headless runs for the 5-node random topology scenario
+# Usage: mc_random_5nodes.sh [NUM_SEEDS] [OUTDIR]
+# - NUM_SEEDS: số lần chạy (mặc định 10)
+# - OUTDIR: thư mục lưu kết quả (mặc định examples/waco-srdcp/sim/out/waco-srdcp-random-5-nodes-mc)
+
+NUM_SEEDS=${1:-10}
+
+# Chuẩn hoá đường dẫn tuyệt đối để chạy từ bất kỳ thư mục nào
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+OUTDIR=${2:-"$ROOT_DIR/examples/waco-srdcp/sim/out/waco-srdcp-random-5-nodes-mc"}
+
+COOJA_BUILD_XML="$ROOT_DIR/tools/cooja/build.xml"
+SCEN="$ROOT_DIR/examples/waco-srdcp/sim/waco-srdcp-random-5-nodes/waco-srdcp-random-5-nodes.csc"
+LOGDIR="$ROOT_DIR/examples/waco-srdcp/sim/waco-srdcp-random-5-nodes"
+
+echo "[mcR5] Chuẩn bị thư mục output: $OUTDIR"
+mkdir -p "$OUTDIR"
+
+if ! command -v ant >/dev/null 2>&1; then
+  echo "[mcR5][ERR] Không tìm thấy 'ant' trong PATH" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[mcR5][ERR] Không tìm thấy 'python3' trong PATH" >&2
+  exit 1
+fi
+
+echo "[mcR5] Build cooja jar (nếu cần)"
+ant -q -f "$COOJA_BUILD_XML" jar >/dev/null
+
+for s in $(seq 1 "$NUM_SEEDS"); do
+  echo "[mcR5] Seed $s / $NUM_SEEDS: chạy headless..."
+  ant -q -f "$COOJA_BUILD_XML" run_bigmem -Dargs="-nogui=$SCEN -random-seed=$s" >/dev/null
+
+  # Tìm file log mới nhất, ưu tiên file có timestamp, fallback nếu không có
+  latest_txt=$(ls -t "$LOGDIR"/waco-srdcp-random-5-nodes-*.txt 2>/dev/null | grep -v '_dc\.txt' | head -1 || true)
+  latest_dc=$(ls -t "$LOGDIR"/waco-srdcp-random-5-nodes-*_dc.txt 2>/dev/null | head -1 || true)
+  if [[ -z "${latest_txt}" ]]; then
+    # fallback không có suffix
+    latest_txt="$LOGDIR/waco-srdcp-random-5-nodes.txt"
+    latest_dc="$LOGDIR/waco-srdcp-random-5-nodes_dc.txt"
+  fi
+
+  if [[ ! -f "$latest_txt" ]]; then
+    echo "[mcR5][ERR] Không tìm thấy log TXT sau khi chạy seed=$s" >&2
+    exit 1
+  fi
+
+  dest_txt="$OUTDIR/seed-$s.txt"
+  echo "[mcR5] Seed $s: lưu log -> $dest_txt"
+  echo "[mcR5]   nguồn TXT: $latest_txt"
+  mv "$latest_txt" "$dest_txt"
+  if [[ -n "${latest_dc}" && -f "$latest_dc" ]]; then
+    echo "[mcR5]   nguồn DC:  $latest_dc"
+    mv "$latest_dc" "$OUTDIR/seed-${s}_dc.txt"
+  fi
+
+  echo "[mcR5] Seed $s: parse chỉ số -> CSV"
+  python3 "$ROOT_DIR/examples/waco-srdcp/sim/log_parser.py" "$dest_txt" --out-prefix "$OUTDIR/seed-$s" >/dev/null
+  if [[ -f "$OUTDIR/seed-${s}_dc.txt" ]]; then
+    echo "[mcR5] Seed $s: tính năng lượng (radio) -> CSV"
+    python3 "$ROOT_DIR/examples/waco-srdcp/sim/energy_parser.py" "$OUTDIR/seed-${s}_dc.txt" --out-prefix "$OUTDIR/seed-$s" >/dev/null
+  fi
+done
+
+# Tổng hợp trung bình mạng qua các seed
+agg="$OUTDIR/network_avgs.csv"
+echo "seed,prr_parent(last)_avg,prr_sender(last)_avg,prr_all_nei_avg_avg,PDR_UL(%)_avg,PDR_DL(%)_avg" > "$agg"
+for s in $(seq 1 "$NUM_SEEDS"); do
+  f="$OUTDIR/seed-${s}_network_avg.csv"
+  if [[ -f "$f" ]]; then
+    tail -n +2 "$f" | sed "s/^/$s,/" >> "$agg"
+  fi
+done
+
+# Tổng hợp năng lượng mạng qua các seed (nếu có)
+eagg="$OUTDIR/energy_network_avgs.csv"
+echo "seed,nodes,E_total_sum(J),E_total_avg_per_node(J),P_avg_per_node(mW)" > "$eagg"
+for s in $(seq 1 "$NUM_SEEDS"); do
+  f="$OUTDIR/seed-${s}_energy_network.csv"
+  if [[ -f "$f" ]]; then
+    tail -n +2 "$f" | sed "s/^/$s,/" >> "$eagg"
+  fi
+done
+
+# Trung bình theo node qua các seed (per-node metrics)
+summary_files=("$OUTDIR"/seed-*_summary.csv)
+if [[ -e "${summary_files[0]:-}" ]]; then
+  python3 "$ROOT_DIR/examples/waco-srdcp/sim/agg_per_node.py" --out "$OUTDIR/per_node_avg.csv" "${summary_files[@]}" >/dev/null || true
+fi
+
+# Trung bình theo mote qua các seed (năng lượng radio)
+energy_files=("$OUTDIR"/seed-*_energy_nodes.csv)
+if [[ -e "${energy_files[0]:-}" ]]; then
+  python3 "$ROOT_DIR/examples/waco-srdcp/sim/agg_per_node.py" --out "$OUTDIR/per_node_energy_avg.csv" "${energy_files[@]}" >/dev/null || true
+fi
+
+echo "[mcR5] Hoàn tất. Kết quả nằm ở: $OUTDIR"
+echo "[mcR5] Gợi ý: xem $agg, $eagg hoặc các file *_summary.csv/_network_avg.csv theo seed."

--- a/examples/waco-srdcp/sim/waco-srdcp-random-15-nodes/waco-srdcp-random-15-nodes.csc
+++ b/examples/waco-srdcp/sim/waco-srdcp-random-15-nodes/waco-srdcp-random-15-nodes.csc
@@ -1,0 +1,458 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
+  <simulation>
+    <title>My simulation</title>
+    <randomseed>123457</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>50.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.mspmote.SkyMoteType
+      <identifier>sky1</identifier>
+      <description>Sky Mote Type #sky1</description>
+      <source EXPORT="discard">[CONTIKI_DIR]/examples/waco-srdcp/example-runicast-srdcp-15.c</source>
+      <commands EXPORT="discard">make example-runicast-srdcp-15.sky TARGET=sky</commands>
+      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/waco-srdcp/example-runicast-srdcp-15.sky</firmware>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyButton</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyFlash</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.WakeupRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspSerial</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyLED</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyTemperature</moteinterface>
+    </motetype>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>18.0</x>
+        <y>18.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>1</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>22.5</x>
+        <y>12.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>2</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>27.0</x>
+        <y>24.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>3</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>31.0</x>
+        <y>17.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>4</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>35.5</x>
+        <y>22.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>5</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>28.0</x>
+        <y>32.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>6</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>22.0</x>
+        <y>30.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>7</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>18.5</x>
+        <y>25.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>8</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>24.0</x>
+        <y>36.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>9</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>30.5</x>
+        <y>35.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>10</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>34.0</x>
+        <y>30.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>11</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>26.5</x>
+        <y>18.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>12</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>20.0</x>
+        <y>22.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>13</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>32.0</x>
+        <y>27.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>14</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>23.5</x>
+        <y>27.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>15</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>3</z>
+    <height>160</height>
+    <location_x>400</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.TrafficVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <viewport>2.755681818181818 0.0 0.0 2.755681818181818 68.13215488215485 119.63552188552192</viewport>
+    </plugin_config>
+    <width>400</width>
+    <z>2</z>
+    <height>400</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter>APP-DL</filter>
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1446</width>
+    <z>-1</z>
+    <height>983</height>
+    <location_x>430</location_x>
+    <location_y>30</location_y>
+    <minimized>true</minimized>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>var LOG_DIR              = "/home/chuongvo/waco/examples/waco-srdcp/sim/waco-srdcp-random-15-nodes";      // vd: "/home/user/cooja-logs" hay "C:\\temp\\cooja"
+var LOG_BASENAME         = "waco-srdcp-random-15-nodes";      // sẽ tạo &lt;LOG_DIR&gt;/&lt;LOG_BASENAME&gt;.log và *_dc.log
+var APPEND_TO_EXISTING   = false;       // true = ghi nối tiếp, false = ghi đè
+var ADD_TIMESTAMP_SUFFIX = true;        // true = gắn "-yyyyMMdd-HHmmss" vào tên file
+var SIM_SETTLING_TIME    = 240000;       // 20s
+TIMEOUT(1800000);                       // 30 phút
+// =======================================
+
+try { load("nashorn:mozilla_compat.js"); } catch(err) {}
+
+importPackage(java.io);
+importPackage(java.util);
+
+// Bảo đảm thư mục tồn tại + tạo tên file theo cấu hình
+var dir = new File(LOG_DIR);
+if (!dir.exists()) { dir.mkdirs(); }
+
+var tsSuffix = "";
+if (ADD_TIMESTAMP_SUFFIX) {
+  var sdf = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss");
+  tsSuffix = "-" + sdf.format(new java.util.Date());
+}
+
+var outFile = new File(dir, LOG_BASENAME + tsSuffix + ".txt");
+var dcFile  = new File(dir, LOG_BASENAME + tsSuffix + "_dc.txt");
+
+// Lấy danh sách mote &amp; PowerTracker
+var allm   = sim.getMotes();
+var nmotes = allm.length;
+
+var ptplugin = sim.getCooja().getStartedPlugin("PowerTracker");
+if (ptplugin != null) { ptplugin.reset(); }
+
+// Mở file
+var outputs   = new FileWriter(outFile, APPEND_TO_EXISTING);
+var dcoutputs = new FileWriter(dcFile,  APPEND_TO_EXISTING);
+
+// Reset PowerTracker sau settling
+GENERATE_MSG(SIM_SETTLING_TIME, "Simulation Settling Time");
+
+// Header nhẹ cho log
+outputs.write("=== START " + (new java.util.Date()) + " | motes=" + nmotes + " ===\n");
+
+while (true) {
+  if (typeof msg !== "undefined" &amp;&amp; msg.equals("Simulation Settling Time")) {
+    if (ptplugin != null) { ptplugin.reset(); }
+  } else if (typeof msg !== "undefined" &amp;&amp; typeof id !== "undefined") {
+    // Ghi Mote Output
+    outputs.write(time + "\tID:" + id + "\t" + msg + "\n");
+  }
+
+  try {
+    // Chạy chờ sự kiện; TIMEOUT ở trên sẽ ném exception để vào catch()
+    YIELD();
+  } catch (e) {
+    // Khi TIMEOUT ném exception: thu Radio Stats + đóng file
+    if (ptplugin != null) {
+      var stats = ptplugin.radioStatistics();
+      dcoutputs.write(stats + "\n");
+    }
+    outputs.close();
+    dcoutputs.close();
+
+    // Kết thúc script (giữ nguyên cách cũ)
+    throw('test script killed');
+  }
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <width>1446</width>
+    <z>-1</z>
+    <height>983</height>
+    <location_x>430</location_x>
+    <location_y>30</location_y>
+    <minimized>true</minimized>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1476</width>
+    <z>1</z>
+    <height>240</height>
+    <location_x>400</location_x>
+    <location_y>160</location_y>
+  </plugin>
+  <plugin>
+    PowerTracker
+    <width>400</width>
+    <z>0</z>
+    <height>400</height>
+    <location_x>7</location_x>
+    <location_y>495</location_y>
+  </plugin>
+</simconf>
+

--- a/examples/waco-srdcp/sim/waco-srdcp-random-30-nodes/waco-srdcp-random-30-nodes.csc
+++ b/examples/waco-srdcp/sim/waco-srdcp-random-30-nodes/waco-srdcp-random-30-nodes.csc
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
+  <simulation>
+    <title>My simulation</title>
+    <randomseed>123459</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>50.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.mspmote.SkyMoteType
+      <identifier>sky1</identifier>
+      <description>Sky Mote Type #sky1</description>
+      <source EXPORT="discard">[CONTIKI_DIR]/examples/waco-srdcp/example-runicast-srdcp-30.c</source>
+      <commands EXPORT="discard">make example-runicast-srdcp-30.sky TARGET=sky</commands>
+      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/waco-srdcp/example-runicast-srdcp-30.sky</firmware>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyButton</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyFlash</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.WakeupRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspSerial</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyLED</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyTemperature</moteinterface>
+    </motetype>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>12.0</x>
+        <y>14.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>1</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>16.5</x>
+        <y>10.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>2</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>21.0</x>
+        <y>13.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>3</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>25.5</x>
+        <y>16.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>4</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>30.0</x>
+        <y>12.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>5</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>34.5</x>
+        <y>15.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>6</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>38.0</x>
+        <y>18.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>7</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>27.0</x>
+        <y>20.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>8</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>32.5</x>
+        <y>21.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>9</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>22.0</x>
+        <y>19.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>10</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>17.5</x>
+        <y>22.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>11</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>13.0</x>
+        <y>19.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>12</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>18.0</x>
+        <y>27.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>13</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>23.5</x>
+        <y>26.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>14</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>28.0</x>
+        <y>25.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>15</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>33.0</x>
+        <y>26.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>16</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>37.5</x>
+        <y>24.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>17</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>40.0</x>
+        <y>28.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>18</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>35.0</x>
+        <y>30.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>19</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>30.5</x>
+        <y>31.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>20</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>25.0</x>
+        <y>29.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>21</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>20.5</x>
+        <y>30.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>22</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>15.0</x>
+        <y>31.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>23</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>18.5</x>
+        <y>35.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>24</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>23.0</x>
+        <y>34.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>25</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>27.5</x>
+        <y>33.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>26</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>32.0</x>
+        <y>34.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>27</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>36.5</x>
+        <y>33.5</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>28</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>41.0</x>
+        <y>32.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>29</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>29.0</x>
+        <y>37.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>30</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>2</z>
+    <height>160</height>
+    <location_x>400</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter>APP-DL</filter>
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1046</width>
+    <z>1</z>
+    <height>240</height>
+    <location_x>259</location_x>
+    <location_y>733</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>var LOG_DIR              = "/home/chuongvo/waco/examples/waco-srdcp/sim/waco-srdcp-random-30-nodes";      // vd: "/home/user/cooja-logs" hay "C:\\temp\\cooja"
+var LOG_BASENAME         = "waco-srdcp-random-30-nodes";      // sẽ tạo &lt;LOG_DIR&gt;/&lt;LOG_BASENAME&gt;.log và *_dc.log
+var APPEND_TO_EXISTING   = false;       // true = ghi nối tiếp, false = ghi đè
+var ADD_TIMESTAMP_SUFFIX = true;        // true = gắn "-yyyyMMdd-HHmmss" vào tên file
+var SIM_SETTLING_TIME    = 240000;       // 20s
+TIMEOUT(1800000);                       // 30 phút
+// =======================================
+
+try { load("nashorn:mozilla_compat.js"); } catch(err) {}
+
+importPackage(java.io);
+importPackage(java.util);
+
+// Bảo đảm thư mục tồn tại + tạo tên file theo cấu hình
+var dir = new File(LOG_DIR);
+if (!dir.exists()) { dir.mkdirs(); }
+
+var tsSuffix = "";
+if (ADD_TIMESTAMP_SUFFIX) {
+  var sdf = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss");
+  tsSuffix = "-" + sdf.format(new java.util.Date());
+}
+
+var outFile = new File(dir, LOG_BASENAME + tsSuffix + ".txt");
+var dcFile  = new File(dir, LOG_BASENAME + tsSuffix + "_dc.txt");
+
+// Lấy danh sách mote &amp; PowerTracker
+var allm   = sim.getMotes();
+var nmotes = allm.length;
+
+var ptplugin = sim.getCooja().getStartedPlugin("PowerTracker");
+if (ptplugin != null) { ptplugin.reset(); }
+
+// Mở file
+var outputs   = new FileWriter(outFile, APPEND_TO_EXISTING);
+var dcoutputs = new FileWriter(dcFile,  APPEND_TO_EXISTING);
+
+// Reset PowerTracker sau settling
+GENERATE_MSG(SIM_SETTLING_TIME, "Simulation Settling Time");
+
+// Header nhẹ cho log
+outputs.write("=== START " + (new java.util.Date()) + " | motes=" + nmotes + " ===\n");
+
+while (true) {
+  if (typeof msg !== "undefined" &amp;&amp; msg.equals("Simulation Settling Time")) {
+    if (ptplugin != null) { ptplugin.reset(); }
+  } else if (typeof msg !== "undefined" &amp;&amp; typeof id !== "undefined") {
+    // Ghi Mote Output
+    outputs.write(time + "\tID:" + id + "\t" + msg + "\n");
+  }
+
+  try {
+    // Chạy chờ sự kiện; TIMEOUT ở trên sẽ ném exception để vào catch()
+    YIELD();
+  } catch (e) {
+    // Khi TIMEOUT ném exception: thu Radio Stats + đóng file
+    if (ptplugin != null) {
+      var stats = ptplugin.radioStatistics();
+      dcoutputs.write(stats + "\n");
+    }
+    outputs.close();
+    dcoutputs.close();
+
+    // Kết thúc script (giữ nguyên cách cũ)
+    throw('test script killed');
+  }
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <width>1043</width>
+    <z>3</z>
+    <height>700</height>
+    <location_x>267</location_x>
+    <location_y>30</location_y>
+  </plugin>
+  <plugin>
+    PowerTracker
+    <width>400</width>
+    <z>0</z>
+    <height>400</height>
+    <location_x>430</location_x>
+    <location_y>30</location_y>
+  </plugin>
+</simconf>
+

--- a/examples/waco-srdcp/sim/waco-srdcp-random-5-nodes/waco-srdcp-random-5-nodes.csc
+++ b/examples/waco-srdcp/sim/waco-srdcp-random-5-nodes/waco-srdcp-random-5-nodes.csc
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
+  <simulation>
+    <title>My simulation</title>
+    <randomseed>123457</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>50.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.mspmote.SkyMoteType
+      <identifier>sky1</identifier>
+      <description>Sky Mote Type #sky1</description>
+      <source EXPORT="discard">[CONTIKI_DIR]/examples/waco-srdcp/example-runicast-srdcp.c</source>
+      <commands EXPORT="discard">make example-runicast-srdcp.sky TARGET=sky</commands>
+      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/waco-srdcp/example-runicast-srdcp.sky</firmware>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyButton</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyFlash</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.WakeupRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspSerial</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyLED</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyTemperature</moteinterface>
+    </motetype>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>10.0</x>
+        <y>15.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>1</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>35.0</x>
+        <y>25.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>2</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>25.0</x>
+        <y>45.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>3</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>50.0</x>
+        <y>30.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>4</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>15.0</x>
+        <y>55.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>5</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>3</z>
+    <height>160</height>
+    <location_x>400</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.TrafficVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <viewport>4.8989898989899 0.0 0.0 4.8989898989899 47.53030303030302 87.51515151515153</viewport>
+    </plugin_config>
+    <width>400</width>
+    <z>-1</z>
+    <height>400</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+    <minimized>true</minimized>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter>APP-DL</filter>
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1046</width>
+    <z>1</z>
+    <height>240</height>
+    <location_x>354</location_x>
+    <location_y>323</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>var LOG_DIR              = "/home/chuongvo/waco/examples/waco-srdcp/sim/waco-srdcp-random-5-nodes";      // vd: "/home/user/cooja-logs" hay "C:\\temp\\cooja"
+var LOG_BASENAME         = "waco-srdcp-random-5-nodes";      // sẽ tạo &lt;LOG_DIR&gt;/&lt;LOG_BASENAME&gt;.log và *_dc.log
+var APPEND_TO_EXISTING   = false;       // true = ghi nối tiếp, false = ghi đè
+var ADD_TIMESTAMP_SUFFIX = true;        // true = gắn "-yyyyMMdd-HHmmss" vào tên file
+var SIM_SETTLING_TIME    = 240000;       // 20s
+TIMEOUT(1800000);                       // 30 phút
+// =======================================
+
+try { load("nashorn:mozilla_compat.js"); } catch(err) {}
+
+importPackage(java.io);
+importPackage(java.util);
+
+// Bảo đảm thư mục tồn tại + tạo tên file theo cấu hình
+var dir = new File(LOG_DIR);
+if (!dir.exists()) { dir.mkdirs(); }
+
+var tsSuffix = "";
+if (ADD_TIMESTAMP_SUFFIX) {
+  var sdf = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss");
+  tsSuffix = "-" + sdf.format(new java.util.Date());
+}
+
+var outFile = new File(dir, LOG_BASENAME + tsSuffix + ".txt");
+var dcFile  = new File(dir, LOG_BASENAME + tsSuffix + "_dc.txt");
+
+// Lấy danh sách mote &amp; PowerTracker
+var allm   = sim.getMotes();
+var nmotes = allm.length;
+
+var ptplugin = sim.getCooja().getStartedPlugin("PowerTracker");
+if (ptplugin != null) { ptplugin.reset(); }
+
+// Mở file
+var outputs   = new FileWriter(outFile, APPEND_TO_EXISTING);
+var dcoutputs = new FileWriter(dcFile,  APPEND_TO_EXISTING);
+
+// Reset PowerTracker sau settling
+GENERATE_MSG(SIM_SETTLING_TIME, "Simulation Settling Time");
+
+// Header nhẹ cho log
+outputs.write("=== START " + (new java.util.Date()) + " | motes=" + nmotes + " ===\n");
+
+while (true) {
+  if (typeof msg !== "undefined" &amp;&amp; msg.equals("Simulation Settling Time")) {
+    if (ptplugin != null) { ptplugin.reset(); }
+  } else if (typeof msg !== "undefined" &amp;&amp; typeof id !== "undefined") {
+    // Ghi Mote Output
+    outputs.write(time + "\tID:" + id + "\t" + msg + "\n");
+  }
+
+  try {
+    // Chạy chờ sự kiện; TIMEOUT ở trên sẽ ném exception để vào catch()
+    YIELD();
+  } catch (e) {
+    // Khi TIMEOUT ném exception: thu Radio Stats + đóng file
+    if (ptplugin != null) {
+      var stats = ptplugin.radioStatistics();
+      dcoutputs.write(stats + "\n");
+    }
+    outputs.close();
+    dcoutputs.close();
+
+    // Kết thúc script (giữ nguyên cách cũ)
+    throw('test script killed');
+  }
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <width>702</width>
+    <z>2</z>
+    <height>312</height>
+    <location_x>687</location_x>
+    <location_y>9</location_y>
+  </plugin>
+  <plugin>
+    PowerTracker
+    <width>400</width>
+    <z>0</z>
+    <height>400</height>
+    <location_x>2</location_x>
+    <location_y>13</location_y>
+  </plugin>
+</simconf>
+


### PR DESCRIPTION
## Summary
- add 15-node random WaCo/SRDCP COOJA scenario with refreshed coordinates and logging paths
- add 30-node random scenario plus headless Monte Carlo wrappers for the 15- and 30-node layouts
- document the expanded random-topology options and scripts in the project READMEs

## Testing
- bash -n examples/waco-srdcp/sim/mc_random_15nodes.sh
- bash -n examples/waco-srdcp/sim/mc_random_30nodes.sh

------
https://chatgpt.com/codex/tasks/task_e_68c8e3c7ba888326b98fc416cd43e3d6